### PR TITLE
fix: senast ändrad text

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -18,12 +18,6 @@ Might want to allow editing
 /* Change the color of the doc rightside sidebar links */
 .td-sidebar-toc a { color: grey !important; }
 
-/* 
-Hide links to the last change commit.
-Ugly workaround that leves to colon ":"
-*/
-.td-page-meta__lastmod a { display: none; }
-
 /* Formating of inline <code> blocks */
 code {
     background-color: #f0f0f0;

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,0 +1,5 @@
+{{ if and .GitInfo .Site.Params.github_repo -}}
+<div class="td-page-meta__lastmod">
+  {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
+</div>
+{{ end -}}


### PR DESCRIPTION
Var inne och tittade på siten sådär som man gör ibland och noterade `:` efter `Senast ändrad ` texten i botten på docs.
_Jag har bråkat lite med liknande funktion på eget hörn_

Tog en snabb titt och hittade
```
/* 
Hide links to the last change commit.
Ugly workaround that leves to colon ":"
*/
.td-page-meta__lastmod a { display: none; }
```

Docsy temat _vill_ att man ska visa hela schabraket via `{{ .GitInfo }}` i `hugo.yaml`, om man stänger av den tappar man dock hela strängen!
Lösningen är att lägga på en överskrivande layout.
Plockad från https://github.com/google/docsy/tree/main/layouts/partials och uppdaterad till att inte via `:` samt som en liten bonus inte ens skapa den med css gömda länken. Därmed kan också cssen städas lite.

## resultat
![image](https://github.com/user-attachments/assets/bdcb5065-ecdc-4707-ae76-22fb8245d18b)
