### PR TITLE
bump HUGO to 0.145.0

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.145.0'
           extended: true
 
       - name: Build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   site:
-    image: hugomods/hugo:exts
+    image: hugomods/hugo:exts-0.145.0
     command: server --buildDrafts --poll 500ms
     ports:
       - "1313:1313"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
-version: "3.8"
+name: sthlm-mesh
 
 services:
-
   site:
     image: hugomods/hugo:exts-0.145.0
     command: server --buildDrafts --poll 500ms


### PR DESCRIPTION
- lock hugo to 0.145.0 in docker-compose and cump to 0.145.0 in GitHub Actions
https://github.com/google/docsy/issues/2213

- remove version and add name to docker-compose
https://docs.docker.com/reference/compose-file/version-and-name/