### PR TITLE
Hugo 0.145.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     interval: daily
     time: '20:00'
   open-pull-requests-limit: 10
+  ignore:
+    # Freeze hugo-extended due to theme issue.
+    - dependency-name: "hugo-extended"
+      versions: ["*"]
 - package-ecosystem: bundler
   directory: "/"
   schedule:

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.145.0'
+          hugo-version: '0.145.0' # Freeze hugo due to theme issue.
           extended: true
 
       - name: Build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ name: sthlm-mesh
 
 services:
   site:
-    image: hugomods/hugo:exts-0.145.0
+    image: hugomods/hugo:exts-0.145.0 # Freeze hugo due to theme issue.
     command: server --buildDrafts --poll 500ms
     ports:
       - "1313:1313"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "cross-env": "^7.0.3",
-    "hugo-extended": "0.146.5",
+    "hugo-extended": "0.145.0",
     "postcss-cli": "^11.0.0",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
uppföljning till: https://github.com/Roslund/sthlm-mesh/pull/12

Låser även npm dependencyn för `hugo-extended` till 0.145.0, samt konfigurerar om dependabot till att inte försöka uppdatera den.

Lägger även till kommentarer på tidigare låsningar, så kanske man kommer ihåg att uppdatera sen när docsy är fixad till att kunna arbeta med den nyare versionen av hugo.

