### PR TITLE
Fix stray character in messages page

### DIFF
--- a/content/sv/messages/index.html
+++ b/content/sv/messages/index.html
@@ -3,7 +3,7 @@ title: Meddelanden
 linkTitle: Meddelanden
 menu: {main: {weight: 50}}
 ---
-<section id="messages" class="pt-0 row td-box td-box--white td-box--height-auto" style="padding-bottom: 0px !important;"x>
+<section id="messages" class="pt-0 row td-box td-box--white td-box--height-auto" style="padding-bottom: 0px !important;">
     <h2 id="senaste-meddelanden" class="pt-3">Senaste meddelanden<a class="td-heading-self-link" href="#senaste-meddelanden" aria-label="Heading self-link"></a></h2>
     
     <div class="btn-toolbar mb-2" role="toolbar" aria-label="Toolbar with button groups">


### PR DESCRIPTION
## Summary
- fix typo in messages section

## Testing
- `npm test` *(fails: hugo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c0c9aacc832182442c34e84b3289