### PR TITLE
Potential fix for code scanning alert no. 2: Replacement of a substring with itself

### DIFF
--- a/static/js/messages.js
+++ b/static/js/messages.js
@@ -140,7 +140,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     function formatMessageTimestamp(createdAt) {
         const date = new Date(createdAt);
-        return date.toLocaleString('sv-SE', { hour12: false }).replace(' ', ' ').slice(0, 16);
+        return date.toLocaleString('sv-SE', { hour12: false }).slice(0, 16);
     }
 
     await fetchMessages();


### PR DESCRIPTION
Potential fix for [https://github.com/Roslund/sthlm-mesh/security/code-scanning/2](https://github.com/Roslund/sthlm-mesh/security/code-scanning/2)

To fix this issue, we should remove the unnecessary call to `replace(' ', ' ')` on line 143. This will eliminate the redundant operation while preserving the intended functionality of the code. The rest of the logic in the `formatMessageTimestamp` function remains intact, and no additional changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
