### PR TITLE
Fix spelling and grammar issues in Swedish docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # STHLM-MESH
 
-**[STHLM-MESH](https://sthlm-mesh.se)** är webbsida byggd med [Hugo][] och använder [Docsy][] som tema.
-Sidan riktar sig till de som är intresserade av LoRa mesh teknologi i allmänhet. Med huvudfokus är det [Meshtastic][] mesh i som omfattar Stockholms området. 
+**[STHLM-MESH](https://sthlm-mesh.se)** är en webbsida byggd med [Hugo][] och använder [Docsy][] som tema.
+Sidan riktar sig till de som är intresserade av LoRa mesh-teknologi i allmänhet. Med huvudfokus är det [Meshtastic][]-mesh som omfattar Stockholmsområdet.
 
 Innehållet skrivs på svenska eller svengelska. Sidan har stöd för flera språk, men att översätta innehållet till engelska är inte prioriterat, då det finns redan massvis med information om Meshtastic på Engelska.
 

--- a/content/sv/docs/device_role.md
+++ b/content/sv/docs/device_role.md
@@ -20,7 +20,7 @@ Därför är det viktigt att `CLIENT`-noder i större meshnätverk placeras väl
 ## Client Mute
 `CLIENT_MUTE`-rollen liknar `CLIENT` men med en viktig skillnad – den vidarebefordrar eller routar inga meddelanden. Detta gör den idealisk för större meshnätverk med hög nätverkstrafik, där extra routing kan orsaka överbelastning.
 
-För de som har flera enheter på samma plats rekommenderas att **max en** enhet sätts som `CLIENT` medan resten får rollen `CLIENT_MUTE` för att minska onödig trafik och optimera nätverkets prestanda.
+För de som har flera enheter på samma plats rekommenderas att **högst en** enhet sätts som `CLIENT` medan resten får rollen `CLIENT_MUTE` för att minska onödig trafik och optimera nätverkets prestanda.
 
 I Stockholm bör portabla noder och noder man har inomhus primärt vara `CLIENT MUTE`.
 
@@ -31,17 +31,17 @@ Routrar vidarebefordrar meddelanden från andra enheter direkt, medan andra node
 
 Routrar vidarebefordrar alltid, medan andra roller kan välja att inte vidarebefordra om de hör en granne vidarebefordra först.
 
-För att optimera nätverkets prestanda och undvika kollisioner bör `ROUTER`-noder placeras så att **så få noder som möjligt når mer än en ROUTER samtidigt.** Detta då om ett meddelanden når flera routrar, så kommer de alla vidarebefordra meddelande samtidigt och störa ut varandra.
+För att optimera nätverkets prestanda och undvika kollisioner bör `ROUTER`-noder placeras så att **så få noder som möjligt når mer än en ROUTER samtidigt.** Detta eftersom om ett meddelande når flera routrar kommer de alla att vidarebefordra meddelandet samtidigt och störa ut varandra.
 
 {{% alert title="Tips" color="primary" %}}
-Sänk `max_hops`. En välplacerad router når långt med bara **ett eller två hopp**. Din router bör nå en nod med MQTT uplink, så att du kan få den telemetri du behöver via [kartan](https://meshtastic.liamcottle.net/)
+Sänk `max_hops`. En välplacerad router når långt med bara **ett eller två hopp**. Din router bör nå en nod med MQTT-uplink så att du kan få den telemetri du behöver via [kartan](https://meshtastic.liamcottle.net/)
 {{% /alert %}}
 
 
 ## Router Late
-`ROUTER_LATE`-rollen är lik `ROUTER`, den vidarebefordrar alla meddelanden, men den gör det under samma tidsfönster som `CLIENT` noder. Detta kan vara mycket användbart i områden där man når ut till meshen, men har svårt att ta emot alla meddelanden. 
+`ROUTER_LATE`-rollen liknar `ROUTER`: den vidarebefordrar alla meddelanden, men den gör det under samma tidsfönster som `CLIENT`-noder. Detta kan vara mycket användbart i områden där man når ut till meshen men har svårt att ta emot alla meddelanden.
 
 ## Repeater
-`REPEATER`-rollen fungerar liknande `ROUTER`-rollen, men går ett steg längre genom att enbart vidarebefordra den meddelanden den tar emot. Den skickar inte ut några paket om sig själv, tex. nod-info.
+`REPEATER`-rollen fungerar liknande `ROUTER`-rollen men går ett steg längre genom att enbart vidarebefordra de meddelanden den tar emot. Den skickar inte ut några paket om sig själv, t.ex. nod-info.
 
-Detta är en mycket effektiv roll. Men vi rekommenderar istället att använda `ROUTER` med optimerade inställningar, så att noden syns och registreras som en aktiv del av meshnätverket.
+Detta är en mycket effektiv roll. Men vi rekommenderar istället att använda `ROUTER` med optimerade inställningar så att noden syns och registreras som en aktiv del av meshnätverket.

--- a/content/sv/docs/neighbor_info.md
+++ b/content/sv/docs/neighbor_info.md
@@ -2,9 +2,9 @@
 title: Neighbor Info
 weight: 70
 ---
-[Neighbor Info modulen](https://meshtastic.org/docs/configuration/module/neighbor-info/) samlar information om en nods grannar som den har direktkontakt med (0-hopp). Denna information kan sedan skickas över MQTT eller LoRa.
+[Neighbor Info-modulen](https://meshtastic.org/docs/configuration/module/neighbor-info/) samlar information om en nods grannar som den har direktkontakt med (0-hopp). Denna information kan sedan skickas över MQTT eller LoRa.
 
-Informationen kan sedan visualiseras på karttjänster. Liam Cottles karta visar information om varje förbindelse. Utöver SNR visas även en terränggraf från [HeyWhatsThat.com](HeyWhatsThat.com).
+Informationen kan sedan visualiseras på karttjänster. Liam Cottles karta visar information om varje förbindelse. Utöver SNR visas även en terränggraf från [HeyWhatsThat.com](https://www.heywhatsthat.com).
 
 
 {{< figure src="/images/docs/neighbors.png" width="400px" height="300px" >}}
@@ -23,11 +23,11 @@ neighbor_info:
     neighbor_info.update_interval: 43200
 {{< /card>}}
 
-### För ROUTERS
+### För routrar
 Att skicka Neighbor Info över LoRa rekommenderas inte, eftersom det använder mycket bandbredd.
 Men för vissa noder, särskilt routrar, kan det ändå vara intressant.
 
 I senare versioner av firmware tillåts det inte att skicka Neighbor Info över standardkanaler, t.ex. LongFast.
-Denna begränsning fungerar bättre i USA, där de olika kanalerna får sina egna frekvens-slotar. I EU spelar detta dock ingen roll.
+Denna begränsning fungerar bättre i USA, där de olika kanalerna får sina egna frekvensslotar. I EU spelar detta dock ingen roll.
 
 För att kringgå denna begränsning måste man ta bort spärren i koden och själv kompilera sin firmware.

--- a/content/sv/docs/position.md
+++ b/content/sv/docs/position.md
@@ -2,35 +2,35 @@
 title: Position
 weight: 30
 ---
-En nod kan dela sin position till alla andra noder över meshet. 
-Det gör det möjligt att se hur meshset sträcker sig geografiskt.
+En nod kan dela sin position till alla andra noder över meshet.
+Det gör det möjligt att se hur meshet sträcker sig geografiskt.
 
 För att dela position behövs antingen en GPS-modul eller en ansluten smartphone.
-Alternativt så kan man sätta en _fixed location_  där man själv anger koordinater, eller använder telefonens nuvarande position. 
+Alternativt kan man sätta en _fixed location_ där man själv anger koordinater eller använder telefonens nuvarande position.
 
 
 ## Position Precision
 Som standard kommer din nod inte dela med sig av sin exakta position. Den kommer skicka en position och en noggrannhet. Detta visar sig som en cirkel runt noden på karta, där din nod är någonstans inom den cirkeln.
 
 ![](/images/docs/position_precision_circles.jpeg)
-Detta gör att du inte avslöjar din exakta address, eller den exakta positionen på din solnod. 
+Detta gör att du inte avslöjar din exakta adress eller den exakta positionen på din solnod.
 Men följddefekten blir att kartan blir väldigt stökig. För noder som använder fixed location så kan man istället sätta den positionen en liten bit ifrån din plats, kanske grannhuset?
 
 **Position precision konfigureras i kanalinställningarna.**
 
 {{% alert title="Uppmärksamma" color="warning" %}}
-iPhone appen har begränsat möjligheten att sätta noggrannhet på position til 1.5km. Detta då det kan anses personlig information enligt GDPR. För att konfigurera högre noggrannhet så behöver man använda en annan klient (tex: [web klienten](https://meshtastic.org/docs/software/web-client/) eller [Python CLI](https://meshtastic.org/docs/software/python/cli/))
+iPhone-appen har begränsat möjligheten att sätta noggrannhet på position till 1,5 km. Detta då det kan anses vara personlig information enligt GDPR. För att konfigurera högre noggrannhet behöver man använda en annan klient (t.ex. [webbklienten](https://meshtastic.org/docs/software/web-client/) eller [Python CLI](https://meshtastic.org/docs/software/python/cli/))
 {{% /alert %}}
 
 ## Konfigurera fixed position genom Python CLI
-Som iPhone användare väljer jag att använda [Python CLI](https://meshtastic.org/docs/software/python/cli/) för att konfigurera position.
+Som iPhone-användare väljer jag att använda [Python CLI](https://meshtastic.org/docs/software/python/cli/) för att konfigurera position.
 {{< card code=true lang="yml" >}}
 meshtastic --setlat 59.520790 --setlon 17.922659 --setalt 10
 meshtastic --set position.position_broadcast_secs 43200
 meshtastic --ch-set module_settings.position_precision 32 --ch-index 0
 {{< /card>}}
 
-Är din nod kopplad till MQTT och du använder _map report_ så finns det en position precision inställning även där.
+Är din nod kopplad till MQTT och du använder _map report_ finns det även en inställning för position precision där.
 {{< card code=true lang="yml" >}}
 meshtastic --set mqtt.map_report_settings.position_precision 32
 {{< /card>}}

--- a/content/sv/docs/settings.md
+++ b/content/sv/docs/settings.md
@@ -11,18 +11,18 @@ Här listas rekommenderade inställningar för Stockholm. Inställningarna heter
 |------------------|---------------|-------------|
 | Region           | EU_868        | Den som primärt används i Sverige och EU |
 | Modem Preset     | `MEDIUM_FAST` | Medium Range - Fast            |
-| Max Hops         | 4-5           | Försök håll så lågt som möjligt |
+| Max Hops         | 4-5           | Försök hålla så lågt som möjligt |
 | Transmit Enabled | true          | Kan stängas av vid byta antenn [^1] |
 | Ignore MQTT      | true          | Vidarebefordra inte meddelanden som kommer från MQTT |
-| OK to MQTT       | true          | Kan stängas av föra att inte synas på karttjänsterna [^2] |
+| OK to MQTT       | true          | Kan stängas av för att inte synas på karttjänsterna [^2] |
 
 [^1]: Det kan vara skadligt för enheten att sända utan antenn.
 [^2]: Detta är enbart en vädjan, det finns inget kryptografiskt skydd. Flertalet tjänster ignorerar denna vädjan och publicerar din nod ändå. 
 
 ### Max hops
-Max hops anger i hur många led noder ska vidarebefordra ditt meddelande. Max hops sätts när paket sänds, en nod som vidarebefordrar ett paket minskar _max hops_ med ett. Vad nodens som vidarebefordrar medelande har för max hopps påverkar inte.
+Max hops anger i hur många led noder ska vidarebefordra ditt meddelande. Max hops sätts när paket sänds, en nod som vidarebefordrar ett paket minskar _max hops_ med ett. Vad noden som vidarebefordrar meddelandet har för max hops påverkar inte.
 
-Det kan vara lockande att direkt välja max antal (7) som tillåts. Detta bör dock undvikas då det påverka stabiliteten i hela meshen. Istället rekommenderas man först och främst använda _trace route_ funktionen för att försöka avgöra vilken väg meddelanden tar genom meshen. Kom ihåg att detta inte är deterministiskt och meshen är under ständig förändring. Det brukar krävas ett tjugotal lyckade trace routs för att få ett hum om hur det funkar. Experimentera dig fram till _Max hops_ som funkar för dig. 
+Det kan vara lockande att direkt välja max antal (7) som tillåts. Detta bör dock undvikas då det påverkar stabiliteten i hela meshen. I stället rekommenderas man först och främst använda _trace route_-funktionen för att försöka avgöra vilken väg meddelanden tar genom meshen. Kom ihåg att detta inte är deterministiskt och meshen är under ständig förändring. Det brukar krävas ett tjugotal lyckade trace routes för att få ett hum om hur det funkar. Experimentera dig fram till _Max hops_ som funkar för dig.
 
 För routrar rekommenderas det att ha ett lågt antal max hops. En välplacerad router bör nå långt med enbart ett hopp eller två. Du bör inte ha ett högre antal _max hops_ än vad som krävs för att köra remote admin om du planerar använda dig av det. 
 
@@ -71,5 +71,5 @@ Notera att batterinivå är inkluderad i Device Metrics. Power Metrics är enbar
 | Transmit over LoRa  | False        |
 | Update interval     | 1h (3600s)   |
 
-Om en nod är är uppkopplad mot en MQTT server så kan man skicka neighbor info frekvent.
-Om man vill skicka neighbor info över LoRa så bör man inte skicka oftare än var 12:e timme (43200s). Dock så är detta begränsat i firmware. För mer detaljer se [Neighbor Info]({{% ref neighbor_info.md %}})
+Om en nod är uppkopplad mot en MQTT-server kan man skicka neighbor info frekvent.
+Om man vill skicka neighbor info över LoRa bör man inte skicka oftare än var tolfte timme (43200s). Dock är detta begränsat i firmware. För mer detaljer se [Neighbor Info]({{% ref neighbor_info.md %}})


### PR DESCRIPTION
## Summary
- correct spelling and grammar mistakes in the README introduction
- improve Swedish phrasing and hyphenation in device role, neighbor info, position, and settings docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d955df5ab08321be00073388f7547d