### PR TITLE
Uppdatera mötesplats till Bryggeri Munkbron

### DIFF
--- a/content/sv/blog/meetups/2026-05-13-Meetup.md
+++ b/content/sv/blog/meetups/2026-05-13-Meetup.md
@@ -12,7 +12,7 @@ Ta gärna med din nod, eller visa upp det senaste bygget.
 
 
 
-__📍 Plats:__ TBD - centralt i stan
+__📍 Plats:__ [Bryggeri Munkbron](https://maps.app.goo.gl/V3s2jAiEcUc6eTj47) (Gamla stan)
 __📅 Datum:__ Onsdag 13 Maj
 __⏰ Tid:__ 17:00
 


### PR DESCRIPTION
## Sammanfattning
- Uppdaterar mötesplats för meetup 13 maj till Bryggeri Munkbron i Gamla stan
- Google Maps-länk för enkel navigering